### PR TITLE
:sparkles: Add unit of measurement display

### DIFF
--- a/src/lib/Components/StateLogic.svelte
+++ b/src/lib/Components/StateLogic.svelte
@@ -61,6 +61,8 @@
 	<!-- State  -->
 {:else if state}
 	{@html $lang(state) || state}
+	<!-- Unit of measurement -->
+	{@html attributes?.['unit_of_measurement'] || ''}
 {:else}
 	{$lang('unknown')}
 {/if}


### PR DESCRIPTION
Add Unit of Measurement display after state display.

From:
![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/5648b6da-debe-40ae-b647-07c6839ef657)
To:
![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/94ee4dfb-858d-4b4c-ae64-a607041e5115)
