### PR TITLE
💄 Allow line breaks in sidebar sensor display

### DIFF
--- a/src/lib/Sidebar/Sensor.svelte
+++ b/src/lib/Sidebar/Sensor.svelte
@@ -71,6 +71,7 @@
 
 	.expandable {
 		min-height: 0;
+		white-space: pre-line;
 	}
 
 	span {


### PR DESCRIPTION
I have a sensor (template) whose state is a list of calendar items. It has a `\n` to separate the items.

Ha-fusion in sidebar currently bundles the items together without the line break:
![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/ef2fee62-7674-40e2-b27d-f80936871796)

With this PR the line-break is preserved:
![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/a7637833-3157-4721-a80d-9d6785c9c149)

I don't think this interferes with anything else, but I'm not sure, so hopefully you can comment.