### PR TITLE
:sparkles: Add marquee to state display

### DIFF
--- a/src/lib/Components/StateLogic.svelte
+++ b/src/lib/Components/StateLogic.svelte
@@ -60,11 +60,23 @@
 
 	<!-- State  -->
 {:else if state}
-	{@html $lang(state) || state}
-
-	<!-- Unit -->
-	{#if attributes?.unit_of_measurement}
-		{attributes.unit_of_measurement}
+		{#if selected?.marquee && contentWidth && contentWidth > 153 && !$editMode}
+		{#await import('$lib/Components/Marquee.svelte') then Marquee}
+			<svelte:component this={Marquee.default}>
+				{@html $lang(state) || state}
+				<!-- Unit -->
+				{#if attributes?.unit_of_measurement}
+					{attributes.unit_of_measurement}
+				{/if}
+				{@html '&nbsp;'.repeat(4)}
+			</svelte:component>
+		{/await}
+	{:else}
+		{@html $lang(state) || state}
+		<!-- Unit -->
+		{#if attributes?.unit_of_measurement}
+			{attributes.unit_of_measurement}
+		{/if}
 	{/if}
 {:else}
 	{$lang('unknown')}


### PR DESCRIPTION
Using existing Marquee component and existing boolean property of ButtonItem, this adds marquee display to long states in buttons.

![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/fcc5387c-5a55-4a09-a8ba-a406ab50baa0)

Usage:

```yaml
- type: button
  id: 4466770179869
  entity_id: sensor.fire_tablet_current_page
  marquee: true
```
