### PR TITLE
:sparkles: Add apparent temperature display option

### DIFF
--- a/src/lib/Modal/WeatherConfig.svelte
+++ b/src/lib/Modal/WeatherConfig.svelte
@@ -49,6 +49,7 @@
 				weather_sensor={sel?.weather_sensor}
 				extra_sensor={sel?.extra_sensor}
 				icon_pack={sel?.icon_pack}
+				show_apparent={sel?.show_apparent}
 			/>
 		</div>
 
@@ -133,6 +134,26 @@
 				use:Ripple={$ripple}
 			>
 				<Icon icon="vaadin:grid-small" height="none" />
+			</button>
+		</div>
+
+		<h2>Apparent temperature</h2>
+
+		<div class="button-container">
+			<button
+				class:selected={!sel?.show_apparent}
+				on:click={() => set('show_apparent', false)}
+				use:Ripple={$ripple}
+			>
+				{$lang('no')}
+			</button>
+
+			<button
+				class:selected={sel?.show_apparent}
+				on:click={() => set('show_apparent', true)}
+				use:Ripple={$ripple}
+			>
+				{$lang('yes')}
 			</button>
 		</div>
 

--- a/src/lib/Modal/WeatherConfig.svelte
+++ b/src/lib/Modal/WeatherConfig.svelte
@@ -136,27 +136,29 @@
 				<Icon icon="vaadin:grid-small" height="none" />
 			</button>
 		</div>
+		{#if sel?.entity_id }
+			{#if $states[sel?.entity_id].attributes.apparent_temperature }
+				<h2>Apparent temperature</h2>
 
-		<h2>Apparent temperature</h2>
+				<div class="button-container">
+					<button
+						class:selected={!sel?.show_apparent}
+						on:click={() => set('show_apparent', false)}
+						use:Ripple={$ripple}
+					>
+						{$lang('no')}
+					</button>
 
-		<div class="button-container">
-			<button
-				class:selected={!sel?.show_apparent}
-				on:click={() => set('show_apparent', false)}
-				use:Ripple={$ripple}
-			>
-				{$lang('no')}
-			</button>
-
-			<button
-				class:selected={sel?.show_apparent}
-				on:click={() => set('show_apparent', true)}
-				use:Ripple={$ripple}
-			>
-				{$lang('yes')}
-			</button>
-		</div>
-
+					<button
+						class:selected={sel?.show_apparent}
+						on:click={() => set('show_apparent', true)}
+						use:Ripple={$ripple}
+					>
+						{$lang('yes')}
+					</button>
+				</div>
+			{/if}
+		{/if}
 		<ConfigButtons {sel} />
 	</Modal>
 {/if}

--- a/src/lib/Sidebar/Index.svelte
+++ b/src/lib/Sidebar/Index.svelte
@@ -329,6 +329,7 @@
 								weather_sensor={item?.state}
 								extra_sensor={item?.extra_sensor}
 								icon_pack={item?.icon_pack}
+								show_apparent={item?.show_apparent}
 							/>
 						</button>
 					{/if}

--- a/src/lib/Sidebar/Weather.svelte
+++ b/src/lib/Sidebar/Weather.svelte
@@ -12,6 +12,7 @@
 	export let extra_sensor_icon: string | undefined = undefined;
 	export let weather_sensor: string | undefined = undefined;
 	export let icon_pack: string | undefined = undefined;
+	export let show_apparent: boolean | undefined = undefined;
 
 	let precipitation: string | undefined;
 	let path: string;
@@ -65,9 +66,15 @@
 		</icon>
 
 		{#if attributes?.temperature}
-			<div class="temp">
-				{Math.round(attributes?.temperature)}{attributes?.temperature_unit || '°'}
-			</div>
+			{#if show_apparent}
+				<div class="temp">
+					{Math.round(attributes?.temperature)}{#if attributes.apparent_temperature}({Math.round(attributes?.apparent_temperature)}){/if}{attributes?.temperature_unit || '°'}
+				</div>
+			{:else}
+				<div class="temp">
+					{Math.round(attributes?.temperature)}{attributes?.temperature_unit || '°'}
+				</div>
+			{/if}
 		{/if}
 
 		<div class="state">

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -184,4 +184,5 @@ export interface WeatherItem {
 	icon_pack?: string;
 	extra_sensor?: string;
 	extra_sensor_icon?: string;
+	show_apparent?: boolean;
 }


### PR DESCRIPTION
Ok, this one is a little opinionated, but here it is anyway.
This adds an option to weather sidebar item to display apparent temperature (if available) as well in parenthesis:
![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/1893947c-8376-4ad0-bf81-0e80ee23b5d4)

It adds new boolean property `show_apparent` to Weather type:

```yaml
  - type: weather
    entity_id: weather.openweathermap
    weather_sensor: sensor.openweathermap_weather
    extra_sensor: sensor.openweathermap_forecast_precipitation_probability
    extra_sensor_icon: mdi:drop
    show_apparent: true
    icon_pack: meteocons
```
which is also configurable from the UI:
![obraz](https://github.com/matt8707/ha-fusion/assets/2185791/a213a534-a963-4519-ba8e-be7a85116fbb)
This is only shown and available to be changed when the selected weather entity actually has an `apparent_temperature` attribute.


The "Apparent temperature" text is not translated, as I'm not sure how to do that yet, where to put it.

PS.
I tried to do toggle in weather config modal using Toggle component, but couldn't get the app to recognize a change of toggle as a settings change (the Save button was not getting active after toggle) and therefore could not save it, so switched back to this No/Yes view...
