### PR TITLE
Added support for optional toggle to disable detail modal to address PR #54

### DIFF
--- a/src/lib/Main/Button.svelte
+++ b/src/lib/Main/Button.svelte
@@ -25,6 +25,7 @@
 	$: icon = sel?.icon;
 	$: color = sel?.color;
 	$: marquee = sel?.marquee;
+	$: can_open_details = sel?.can_open_details;
 
 	let entity: HassEntity;
 	let contentWidth: number;
@@ -158,6 +159,8 @@
 				demo: entity_id,
 				sel
 			});
+		} else if (can_open_details === false) {
+			toggle();
 		} else {
 			switch (getDomain(sel?.entity_id)) {
 				// light

--- a/src/lib/Modal/ButtonConfig.svelte
+++ b/src/lib/Modal/ButtonConfig.svelte
@@ -196,9 +196,11 @@
 			/>
 		</InputClear>
 
-		<h2>{$lang('show_details_on_interaction')}</h2>
-		<div style:margin-top="1.3rem">
-			<Toggle bind:checked={canOpen} />
+		<div class="interaction_container">
+			<h2>{$lang('show_details_on_interaction')}</h2>
+			<div style:margin-top="1.3rem">
+				<Toggle bind:checked={canOpen} />
+			</div>
 		</div>
 
 		{#if getDomain(entity_id) === 'media_player'}
@@ -226,3 +228,11 @@
 		<ConfigButtons {sel} />
 	</Modal>
 {/if}
+
+<style>
+	.interaction_container {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+	}
+</style>

--- a/src/lib/Modal/ButtonConfig.svelte
+++ b/src/lib/Modal/ButtonConfig.svelte
@@ -7,11 +7,14 @@
 	import Icon from '@iconify/svelte';
 	import Ripple from 'svelte-ripple';
 	import InputClear from '$lib/Components/InputClear.svelte';
+	import Toggle from '$lib/Components/Toggle.svelte';
 	import ConfigButtons from '$lib/Modal/ConfigButtons.svelte';
 	import { updateObj, getDomain, getName } from '$lib/Utils';
 	import type { ButtonItem } from '$lib/Types';
 
 	export let isOpen: boolean;
+	export let canOpen: boolean;
+
 	export let sel: ButtonItem;
 	export let demo: string | undefined = undefined;
 
@@ -28,6 +31,11 @@
 	// (maybe make reactive)
 
 	$: entity_id = sel?.entity_id;
+	$: canOpen, set('can_open_details', canOpen);
+
+	if (canOpen === undefined) {
+		canOpen = true;
+	}
 
 	let icon: string | undefined = sel?.icon;
 
@@ -187,6 +195,11 @@
 				style:padding
 			/>
 		</InputClear>
+
+		<h2>{$lang('show_details_on_interaction')}</h2>
+		<div style:margin-top="1.3rem">
+			<Toggle bind:checked={canOpen} />
+		</div>
 
 		{#if getDomain(entity_id) === 'media_player'}
 			<h2>Marquee</h2>

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -65,6 +65,7 @@ export interface ButtonItem {
 	icon?: string;
 	color?: string;
 	marquee?: boolean;
+	can_open_details?: boolean;
 }
 
 export type SidebarItem = BarItem &

--- a/static/translations/en.json
+++ b/static/translations/en.json
@@ -151,6 +151,7 @@
 	"settings": "Settings",
 	"shortcuts": "Shortcuts",
 	"show": "Show",
+	"show_details_on_interaction": "Show Details on Interaction",
 	"show_in_sidebar": "Show in sidebar",
 	"sidebar": "Sidebar",
 	"size": "Size",


### PR DESCRIPTION
Added support for optional toggle to disable detail modal so it acts as a full cell toggle. Addressing PR #56. By default any existing button object will have details enabled by default. Only when you manually set an existing object to no details will it stop displaying them. 

You can also set if it should show details when you are creating a new Object as well.

<img width="497" alt="image" src="https://github.com/matt8707/ha-fusion/assets/1327947/6a9c592f-4544-4fa1-b92d-7aa2721d78cd">
