### PR TITLE
Initial card sizes implementation

### DIFF
--- a/src/lib/Main/Camera.svelte
+++ b/src/lib/Main/Camera.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { states, lang, itemHeight, editMode } from '$lib/Stores';
+	import { states, lang, itemHeight, editMode, itemWidth, itemGap } from '$lib/Stores';
 	import { openModal } from 'svelte-modals';
 
 	export let sel: any;
@@ -48,7 +48,8 @@
 	bind:offsetWidth
 	bind:offsetHeight
 	style:aspect-ratio="{width} / {height}"
-	style:height={`calc(${$itemHeight}px * 4 + 0.4rem * 3)`}
+	style:height={`calc(${$itemHeight}px * 4 + ${$itemGap}rem * 3)`}
+	style:width={`calc(${$itemWidth}rem * 4 + ${$itemGap}rem * 3)`}
 	style:background-image={url ? `url(${url})` : 'none'}
 	style:background-size="{offsetHeight * (width / height)}px {offsetHeight}px"
 	style:cursor={!$editMode ? 'pointer' : 'unset'}
@@ -71,7 +72,6 @@
 		background-color: rgba(0, 0, 0, 0.2);
 		border-radius: 0.6rem;
 		overflow: hidden;
-		width: calc(14.5rem * 2 + 0.4rem);
 		background-repeat: no-repeat;
 	}
 

--- a/src/lib/Main/Index.svelte
+++ b/src/lib/Main/Index.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { editMode, motion, record, dragging, itemHeight } from '$lib/Stores';
+	import { editMode, motion, record, dragging, itemHeight, itemWidth, itemGap } from '$lib/Stores';
 	import { tick } from 'svelte';
 	import { flip } from 'svelte/animate';
 	import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import Content from '$lib/Main/Content.svelte';
 	import SectionHeader from '$lib/Main/SectionHeader.svelte';
 	import HorizontalStackHeader from '$lib/Main/HorizontalStackHeader.svelte';
+	import type { ButtonItem } from '$lib/Types';
 
 	export let view: any;
 
@@ -129,18 +130,36 @@
 			min-height: ${itemHeight}px;
 			background-color: ${empty ? 'rgba(255, 190, 10, 0.25)' : 'transparent'};
 			outline: ${empty ? '2px dashed #ffc107' : 'none'};
+			grid-template-columns: repeat(auto-fill, ${$itemWidth}rem);
+			gap: ${$itemGap}rem;
 			transition: ${
 				editMode ? `background-color ${motion / 2}ms ease, min-height ${motion}ms ease` : 'none'
 			};
     `;
 	}
 
-	function itemStyles(type: string) {
-		return `
-			grid-column: ${type === 'media' || type === 'camera' ? 'span 2' : 'span 1'};
-			grid-row: ${type === 'media' || type === 'camera' ? 'span 4' : 'span 1'};
-			display: ${type ? '' : 'none'};
-    `;
+	function itemStyles(item: ButtonItem) {
+		let columnSpan = 3;
+		let rowSpan = 1;
+
+		if (item.size === 'widget') {
+			columnSpan = 2;
+			rowSpan = 2;
+		}
+
+		// Hardcode size for these types, then remove, everything should be driven by size config in the item
+		if (item.type === 'camera' || item.type === 'media') {
+			columnSpan = 4;
+			rowSpan = 4;
+		}
+
+		const styles = `
+			grid-column: span ${columnSpan};
+			grid-row: span ${rowSpan};
+			display: ${item.type ? '' : 'none'};
+		`;
+
+		return styles;
 	}
 </script>
 
@@ -198,7 +217,7 @@
 										class="item"
 										animate:flip={{ duration: $motion }}
 										tabindex="-1"
-										style={itemStyles(item?.type)}
+										style={itemStyles(item)}
 									>
 										<Content {item} />
 									</div>
@@ -265,9 +284,7 @@
 		border-radius: 0.6rem;
 		outline-offset: -2px;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, 14.5rem);
 		grid-auto-rows: min-content;
-		gap: 0.4rem;
 		border-radius: 0.6rem;
 		height: 100%;
 	}

--- a/src/lib/Main/Media.svelte
+++ b/src/lib/Main/Media.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { states, itemHeight, lang, configuration } from '$lib/Stores';
+	import { states, itemHeight, lang, configuration, itemGap, itemWidth } from '$lib/Stores';
 	import Icon from '@iconify/svelte';
 	import ComputeIcon from '$lib/Components/ComputeIcon.svelte';
 	import { getName } from '$lib/Utils';
@@ -84,7 +84,8 @@
 <div
 	class="media-container"
 	style:background-image={backgroundImage}
-	style:height="calc({$itemHeight}px * 4 + 0.4rem * 3)"
+	style:height={`calc(${$itemHeight}px * 4 + ${$itemGap}rem * 3)`}
+	style:width={`calc(${$itemWidth}rem * 4 + ${$itemGap}rem * 3)`}
 >
 	{#if entity?.attributes?.app_id === 'com.google.ios.youtube' && backgroundImage === 'none'}
 		<div class="youtube-icon">
@@ -233,7 +234,6 @@
 		--container-padding: 0.8rem;
 		position: relative;
 		color: white;
-		width: calc(14.5rem * 2 + 0.4rem);
 		border-radius: 0.65rem;
 		background-color: var(--theme-button-background-color-off);
 		background-size: cover;

--- a/src/lib/Modal/ButtonConfig.svelte
+++ b/src/lib/Modal/ButtonConfig.svelte
@@ -24,6 +24,10 @@
 		set('entity_id', demo);
 	}
 
+	const sizes = [
+		{ id: 'compact', label: 'Compact' },
+		{ id: 'widget', label: 'Widget' }
+	];
 	let name = sel?.name;
 
 	// untested
@@ -31,6 +35,7 @@
 	// (maybe make reactive)
 
 	$: entity_id = sel?.entity_id;
+	$: size = sel?.size || 'compact';
 	$: canOpen, set('can_open_details', canOpen);
 
 	if (canOpen === undefined) {
@@ -134,6 +139,16 @@
 				style:padding
 			/>
 		</InputClear>
+
+		<h2>Size</h2>
+		<div class="icon-gallery-container">
+			<Select
+				options={sizes}
+				placeholder="Size"
+				value={size}
+				on:change={(event) => set('size', event)}
+			/>
+		</div>
 
 		<h2>
 			{$lang('icon')}

--- a/src/lib/Stores.ts
+++ b/src/lib/Stores.ts
@@ -41,6 +41,8 @@ export const editMode = writable(false);
 export const showDrawer = writable(false);
 export const motion = writable(190);
 export const itemHeight = readable(65);
+export const itemWidth = readable(4.5);
+export const itemGap = readable(0.5);
 
 // language
 export const translation = writable<Translations>({});

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -61,6 +61,7 @@ export interface ButtonItem {
 	type?: string;
 	id?: number;
 	entity_id?: string;
+	size: string;
 	name?: string;
 	icon?: string;
 	color?: string;


### PR DESCRIPTION
@matt8707 Let me know what you think.

This is a preview:

![image](https://github.com/matt8707/ha-fusion/assets/5721029/891cb133-f1be-4cd8-bb93-b497b71debaf)

Only 2 sizes for now: Compact and Widget.

Thinking on providing 4 sizes: 

- Compact (your original button size)
- Small (what I call Widget here)
- Medium (Sport scores, Dinner menu, pictures, etc.)
- Large (for something like Camera or Media cards, etc.)

Not all card type need to support all sizes, for example, button only supports Compact and Small, media and camera are currently Medium by default

Good source for inspiration: https://developer.apple.com/design/human-interface-guidelines/widgets