### PR TITLE
Added support for overriding display name for graph items.

### DIFF
--- a/src/lib/Modal/GraphConfig.svelte
+++ b/src/lib/Modal/GraphConfig.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { dashboard, connection, lang, history, historyIndex, record } from '$lib/Stores';
+	import { dashboard, states, connection, lang, history, historyIndex, record } from '$lib/Stores';
 	import { onDestroy } from 'svelte';
 	import Graph from '$lib/Sidebar/Graph.svelte';
 	import Select from '$lib/Components/Select.svelte';
 	import ConfigButtons from '$lib/Modal/ConfigButtons.svelte';
+	import InputClear from '$lib/Components/InputClear.svelte';
 	import Modal from '$lib/Modal/Index.svelte';
-	import { updateObj } from '$lib/Utils';
+	import { updateObj, getName } from '$lib/Utils';
 	import type { GraphItem } from '$lib/Types';
 
 	export let isOpen: boolean;
@@ -18,6 +19,8 @@
 		$history.splice($historyIndex, 1);
 		set('entity_id', demo);
 	}
+
+	let name = sel?.name;
 
 	let options: { id: string; label: string }[];
 	let stroke = sel?.stroke;
@@ -91,7 +94,12 @@
 		<h2>{$lang('preview')}</h2>
 
 		<div class="preview">
-			<Graph entity_id={sel?.entity_id} period={sel?.period} stroke={minMax(stroke)} />
+			<Graph
+				entity_id={sel?.entity_id}
+				name={sel?.name}
+				period={sel?.period}
+				stroke={minMax(stroke)}
+			/>
 		</div>
 
 		<h2>{$lang('entity')}</h2>
@@ -105,6 +113,30 @@
 				on:change={(event) => set('entity_id', event)}
 			/>
 		{/if}
+
+		<h2>{$lang('name')}</h2>
+
+		<InputClear
+			condition={name}
+			on:clear={() => {
+				name = undefined;
+				set('name');
+			}}
+			let:padding
+		>
+			<input
+				name={$lang('name')}
+				class="input"
+				type="text"
+				placeholder={getName(sel, (sel.entity_id && $states[sel.entity_id]) || undefined) ||
+					$lang('name')}
+				autocomplete="off"
+				spellcheck="false"
+				bind:value={name}
+				on:change={(event) => set('name', event)}
+				style:padding
+			/>
+		</InputClear>
 
 		<h2>{$lang('period')} (data_points)</h2>
 

--- a/src/lib/Sidebar/Graph.svelte
+++ b/src/lib/Sidebar/Graph.svelte
@@ -4,8 +4,10 @@
 	import { line, area, curveBasis } from 'd3-shape';
 	import { extent, bisector } from 'd3-array';
 	import { getName } from '$lib/Utils';
+	import type { HassEntity } from 'home-assistant-js-websocket';
 
 	export let entity_id: string | undefined;
+	export let name: string | undefined = undefined;
 	export let period = 'day';
 	export let stroke = 2;
 
@@ -88,7 +90,7 @@
 	$: if (entity) {
 		unit_of_measurement = entity?.attributes?.unit_of_measurement || '';
 
-		friendlyName = getName(undefined, entity);
+		friendlyName = getName({ name }, entity);
 
 		state = entity?.state;
 

--- a/src/lib/Sidebar/Index.svelte
+++ b/src/lib/Sidebar/Index.svelte
@@ -240,6 +240,7 @@
 							<svelte:component
 								this={Graph.default}
 								entity_id={item?.entity_id}
+								name={item?.name}
 								period={item?.period}
 								stroke={item?.stroke}
 							/>

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -107,6 +107,7 @@ export interface DateItem {
 }
 
 export interface GraphItem {
+	name?: string;
 	type?: string;
 	id?: number;
 	entity_id?: string;


### PR DESCRIPTION
This added support for overriding the entity friendly name for graph items. Based on issue #68.

<img width="502" alt="image" src="https://github.com/matt8707/ha-fusion/assets/1327947/d7b2f35a-442f-45ae-83e1-4191c5f90289">
