### PR TITLE
update mobile support

### DIFF
--- a/src/lib/Drawer/AddDropdown.svelte
+++ b/src/lib/Drawer/AddDropdown.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	import { dashboard, lang, motion, ripple } from '$lib/Stores';
+	import { cubicOut } from 'svelte/easing';
+	import { fade, slide } from 'svelte/transition';
+	import SidebarButton from '$lib/Drawer/SidebarButton.svelte';
+	import ObjectButton from '$lib/Drawer/ObjectButton.svelte';
+	import SectionButton from '$lib/Drawer/SectionButton.svelte';
+	import HorizontalStackButton from '$lib/Drawer/HorizontalStackButton.svelte';
+	import ViewButton from '$lib/Drawer/ViewButton.svelte';
+	import type { ViewItem } from '$lib/Types';
+	import Icon from '@iconify/svelte';
+	import Ripple from 'svelte-ripple';
+
+	export let view: ViewItem | undefined;
+
+	let isOpen = false;
+	let showTriangle = false;
+	let container: HTMLDivElement;
+
+	function handleClick(event: MouseEvent) {
+		isOpen = !isOpen;
+	}
+
+	/**
+	 * Close dropdown when clicking outside if it
+	 */
+	function handlePointerDown(event: PointerEvent) {
+		if (isOpen && container && !container.contains(event.target as Node)) {
+			isOpen = false;
+		}
+	}
+
+	/**
+	 * Close dropdown on ESC key press
+	 */
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && isOpen) {
+			event.stopPropagation();
+			isOpen = false;
+		}
+	}
+</script>
+
+<svelte:window on:pointerdown|capture={handlePointerDown} on:keydown|capture={handleKeydown} />
+
+<div class="container" bind:this={container}>
+	<button class="button" on:click={handleClick} use:Ripple={$ripple}>
+		<figure>
+			<Icon icon="gridicons:add-outline" height="none" />
+		</figure>
+
+		{$lang('add')}
+	</button>
+
+	{#if isOpen}
+		<div
+			class="dropdown"
+			on:introstart={() => {
+				showTriangle = true;
+			}}
+			on:outrostart={() => {
+				showTriangle = false;
+			}}
+			in:slide={{ duration: $motion, easing: cubicOut }}
+			out:fade={{ duration: $motion / 3, easing: cubicOut }}
+		>
+			{#if !$dashboard.hide_sidebar}
+				<SidebarButton />
+				<hr />
+			{/if}
+
+			<ObjectButton {view} />
+			<hr />
+
+			<SectionButton {view} />
+			<hr />
+
+			<HorizontalStackButton {view} />
+			<hr />
+
+			<ViewButton />
+		</div>
+	{/if}
+
+	{#if showTriangle}
+		<div
+			class="triangle"
+			in:fade={{ duration: $motion / 3, easing: cubicOut }}
+			out:fade={{ duration: $motion / 3, easing: cubicOut }}
+		/>
+	{/if}
+</div>
+
+<style>
+	.container {
+		position: relative;
+		display: grid;
+	}
+
+	.dropdown {
+		position: absolute;
+		top: calc(100% + 8px);
+		background: rgb(29, 27, 24);
+		z-index: 1;
+		border-radius: 0.4rem;
+	}
+
+	.triangle {
+		position: absolute;
+		top: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		width: 0;
+		height: 0;
+		border-left: 8px solid transparent;
+		border-right: 8px solid transparent;
+		border-bottom: 8px solid rgb(29, 27, 24);
+	}
+
+	hr {
+		padding: 0;
+		margin: 0;
+		border-top: none;
+		border-right: none;
+		border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+		border-left: none;
+	}
+</style>

--- a/src/lib/Drawer/Drawer.css
+++ b/src/lib/Drawer/Drawer.css
@@ -22,6 +22,11 @@
 	min-width: 3rem;
 }
 
+#drawer .button.dropdown {
+	background-color: none;
+	width: 100%;
+}
+
 #drawer figure {
 	width: 1.5em;
 	margin: 0 0.2rem 0 0;

--- a/src/lib/Drawer/HorizontalStackButton.svelte
+++ b/src/lib/Drawer/HorizontalStackButton.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <button
-	class="button"
+	class="button dropdown"
 	on:click={handleClick}
 	use:Ripple={{
 		...$ripple,

--- a/src/lib/Drawer/Index.svelte
+++ b/src/lib/Drawer/Index.svelte
@@ -66,7 +66,7 @@
 			<svelte:component this={AppearanceButton.default} />
 		{/await}
 
-		<div class="actions">
+		<div>
 			{#await import('$lib/Drawer/HistoryButtons.svelte') then HistoryButtons}
 				<svelte:component this={HistoryButtons.default} />
 			{/await}
@@ -109,16 +109,15 @@
 		grid-area: header;
 		min-height: 0;
 		display: flex;
-		flex-wrap: wrap;
 		gap: 0.5rem;
-		height: auto;
+		height: 4.75rem;
 		width: 100vw;
 		padding: 1rem 2rem;
 		background-color: var(--theme-colors-sidebar-background);
 		border-bottom: var(--theme-colors-sidebar-border);
 	}
 
-	.actions {
+	div {
 		display: flex;
 		margin-left: auto;
 		margin-right: 3.6rem;

--- a/src/lib/Drawer/Index.svelte
+++ b/src/lib/Drawer/Index.svelte
@@ -36,7 +36,11 @@
 	{#if $editMode}
 		<Separator />
 
-		{#if !$dashboard.hide_sidebar}
+		{#await import('$lib/Drawer/AddDropdown.svelte') then AddDropdown}
+			<svelte:component this={AddDropdown.default} {view} />
+		{/await}
+
+		<!-- {#if !$dashboard.hide_sidebar}
 			{#await import('$lib/Drawer/SidebarButton.svelte') then SidebarButton}
 				<svelte:component this={SidebarButton.default} />
 			{/await}
@@ -60,7 +64,7 @@
 			<svelte:component this={ViewButton.default} />
 		{/await}
 
-		<Separator />
+		<Separator /> -->
 
 		{#await import('$lib/Drawer/AppearanceButton.svelte') then AppearanceButton}
 			<svelte:component this={AppearanceButton.default} />

--- a/src/lib/Drawer/ObjectButton.svelte
+++ b/src/lib/Drawer/ObjectButton.svelte
@@ -57,7 +57,7 @@
 </script>
 
 <button
-	class="button"
+	class="button dropdown"
 	on:click={handleClick}
 	use:Ripple={{
 		...$ripple,

--- a/src/lib/Drawer/SectionButton.svelte
+++ b/src/lib/Drawer/SectionButton.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <button
-	class="button"
+	class="button dropdown"
 	on:click={handleClick}
 	use:Ripple={{
 		...$ripple,

--- a/src/lib/Drawer/SidebarButton.svelte
+++ b/src/lib/Drawer/SidebarButton.svelte
@@ -20,7 +20,7 @@
 	}
 </script>
 
-<button class="button" on:click={handleClick} use:Ripple={$ripple}>
+<button class="button dropdown" on:click={handleClick} use:Ripple={$ripple}>
 	<figure>
 		<Icon icon="solar:sidebar-minimalistic-bold-duotone" height="none" />
 	</figure>

--- a/src/lib/Drawer/ViewButton.svelte
+++ b/src/lib/Drawer/ViewButton.svelte
@@ -48,7 +48,7 @@
 	}
 </script>
 
-<button class="button" on:click={handleClick} use:Ripple={$ripple}>
+<button class="button dropdown" on:click={handleClick} use:Ripple={$ripple}>
 	<figure style:width="1.35rem">
 		<Icon icon="fluent:tab-add-24-filled" height="none" />
 	</figure>

--- a/src/lib/Main/EditViewButton.svelte
+++ b/src/lib/Main/EditViewButton.svelte
@@ -3,8 +3,15 @@
 	import { fade } from 'svelte/transition';
 	import { openModal } from 'svelte-modals';
 	import Ripple from 'svelte-ripple';
+	import { createEventDispatcher } from 'svelte';
 
 	export let view: any;
+
+	const dispatch = createEventDispatcher();
+
+	let clientWidth = 0;
+
+	$: dispatch('change', clientWidth);
 
 	/**
 	 * Opens modal to edit view
@@ -19,6 +26,7 @@
 </script>
 
 <button
+	bind:clientWidth
 	class="edit"
 	on:click={handleClick}
 	transition:fade={{ duration: $motion / 2 }}
@@ -43,7 +51,6 @@
 		display: flex;
 		font-family: inherit;
 		white-space: nowrap;
-		margin-left: 0.4rem;
 		margin-top: 0.25rem;
 	}
 </style>

--- a/src/lib/Main/Views.svelte
+++ b/src/lib/Main/Views.svelte
@@ -75,6 +75,10 @@
 			$currentViewId = paramView?.id;
 		}
 	});
+
+	// navbar = 100% - (sidebar & padding & button & padding)
+	let editViewButtonWidth: number;
+	$: navWidth = `calc(100vw - (${$dashboard?.sidebarWidth}px + 2rem + ${editViewButtonWidth}px + 2rem))`;
 </script>
 
 <nav>
@@ -82,17 +86,19 @@
 	{#if $dashboard.views.length === 0 ? false : $editMode ? true : !$dashboard?.hide_views}
 		<section transition:slide={{ duration: $motion }}>
 			{#if $editMode}
-				<EditViewButton {view} />
+				<EditViewButton
+					{view}
+					on:change={(event) => {
+						editViewButtonWidth = event?.detail;
+					}}
+				/>
 			{/if}
 
 			{#if $dashboard?.hide_views}
 				<EyeIndicator />
 			{/if}
 
-			<div
-				class="navigation-container"
-				style:width="calc(100vw - ({$dashboard?.sidebarWidth}px + 120px))"
-			>
+			<div class="navigation-container" style:width={navWidth}>
 				<div class="fadecont" transition:fade={{ duration: $motion / 2 }}>
 					<div class="top-bar">
 						<div


### PR DESCRIPTION
@janiskelemen, your thoughts?

Updated how nav width (views) are calculated
[more precise way to calc nav width](https://github.com/matt8707/ha-fusion/pull/92/commits/1feecb3d27997be0648cd1f93f57386d715431bf)

Unfortunately I had to revert drawer height, but I got another idea
[drawer height 'auto' breaks animations, revert](https://github.com/matt8707/ha-fusion/pull/92/commits/cc1a2e23e2922c89891ff3528f215ed912ae6693)

With something like this, fitting everything on mobile should be doable
[add dropdown](https://github.com/matt8707/ha-fusion/pull/92/commits/369738bddeb21048cac2ebec3622f1fcde8b25bb)

https://github.com/matt8707/ha-fusion/assets/36163594/ebad291d-8c5c-4988-a600-2df18d564169

