### PR TITLE
Allow section name to be empty

### DIFF
--- a/src/lib/Main/SectionHeader.svelte
+++ b/src/lib/Main/SectionHeader.svelte
@@ -41,6 +41,7 @@
 	header h1 {
 		padding: 0;
 		font-size: 1.8rem;
+		height: 1.8rem;
 		font-weight: 600;
 		margin-block-start: 0;
 		margin-block-end: 0.4rem;

--- a/src/lib/Main/SectionTitle.svelte
+++ b/src/lib/Main/SectionTitle.svelte
@@ -1,18 +1,13 @@
 <script lang="ts">
 	import { editMode, record } from '$lib/Stores';
-	import { onMount, createEventDispatcher } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 
 	export let value: string;
 
 	let width: number;
-	let prevValue: string;
 	let input: HTMLInputElement;
 
 	const dispatch = createEventDispatcher();
-
-	onMount(() => {
-		prevValue = value;
-	});
 
 	/**
 	 * Dispatches title change on submit or blur,
@@ -21,14 +16,9 @@
 	function handleSubmit() {
 		if (!$editMode) return;
 
-		if (value === '') {
-			value = prevValue;
-		}
-
 		dispatch('submit', value);
 		$record();
 
-		prevValue = value;
 		if (input) input.blur();
 	}
 
@@ -56,7 +46,8 @@
 		bind:this={input}
 		on:blur={handleSubmit}
 		on:keydown={handleKeydown}
-		style:width="{width + 1}px"
+		style:width="{value == '' ? width + 100 : width + 1}px"
+		placeholder="Name"
 		required={true}
 		autocomplete="off"
 		spellcheck="false"


### PR DESCRIPTION
Closes #129 

This allows the section name to be empty. When it is empty it shows a placeholder in edit mode and an empty div in normal mode. The latter is to make sure that everything is still aligned. 

This does change the size of the area that can be used to drag the section. 

![image](https://github.com/matt8707/ha-fusion/assets/19775528/b1ea9c29-f277-417c-ac3b-6e2b95e57c50)
![image](https://github.com/matt8707/ha-fusion/assets/19775528/07fd329c-ced7-481f-8e4d-68b9451e7213)

