### PR TITLE
🎉 Custom popup proof of concept

### DIFF
--- a/src/lib/Modal/CustomPopupModal.svelte
+++ b/src/lib/Modal/CustomPopupModal.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	import { dashboard } from '$lib/Stores';
+	import Modal from '$lib/Modal/Index.svelte';
+	import ConfigButtons from '$lib/Modal/ConfigButtons.svelte';
+	import { editMode, motion, itemHeight } from '$lib/Stores';
+	import { flip } from 'svelte/animate';
+	import Content from '$lib/Main/Content.svelte';
+	import SectionHeader from '$lib/Main/SectionHeader.svelte';
+	import HorizontalStackHeader from '$lib/Main/HorizontalStackHeader.svelte';
+	import type { PopupItem } from '$lib/Types';
+
+	export let isOpen: boolean;
+
+	export let popup: string | undefined;
+
+	let view: PopupItem | undefined;
+
+	view = $dashboard.popups?.find(
+			(p) => p.name === popup
+		)
+
+	const stackHeight = $itemHeight * 1.65;
+
+	/**
+	 * The styles a constructed in a function to not have to repeat them inline.
+	 *
+	 * This is because of 'horizontal-stack'; it's not possible to make code
+	 * recursive or use reusable components without breaking flip-animations.
+	 */
+
+	function sectionStyles(itemHeight: number, editMode: boolean, motion: number, empty: boolean) {
+		return `
+			min-height: ${itemHeight}px;
+			background-color: ${empty ? 'rgba(255, 190, 10, 0.25)' : 'transparent'};
+			outline: ${empty ? '2px dashed #ffc107' : 'none'};
+			transition: ${
+				editMode ? `background-color ${motion / 2}ms ease, min-height ${motion}ms ease` : 'none'
+			};
+    `;
+	}
+
+	function itemStyles(type: string) {
+		return `
+			grid-column: ${type === 'media' || type === 'camera' ? 'span 2' : 'span 1'};
+			grid-row: ${type === 'media' || type === 'camera' ? 'span 4' : 'span 1'};
+			display: ${type ? '' : 'none'};
+    `;
+	}
+
+</script>
+
+{#if isOpen}
+	<Modal>
+		<h1 slot="title">{view?.name}</h1>
+
+		<main
+			style:transition="opacity {$motion}ms ease, outline-color {$motion}ms ease"
+			style:opacity={'1'}
+		>
+			{#each view?.sections as section (section?.id)}
+				<section
+					id={String(section?.id)}
+					animate:flip={{ duration: $motion }}
+				>
+					<!-- horizontal stack -->
+					{#if section?.type === 'horizontal-stack'}
+						<HorizontalStackHeader {view} {section} />
+
+						<div
+							class="horizontal-stack"
+							style:min-height="{stackHeight}px"
+							style:outline="2px dashed transparent"
+							style:transition="min-height {$motion}ms ease, outline {$motion / 2}ms ease"
+						>
+							{#each section?.sections as stackSection (stackSection.id)}
+								{@const empty = $editMode && !stackSection?.items?.length}
+								<section
+									id={String(stackSection.id)}
+									animate:flip={{ duration: $motion }}
+									style:overflow="hidden"
+								>
+									<SectionHeader {view} section={stackSection} />
+									<div
+										class="items"
+										style={sectionStyles($itemHeight, $editMode, $motion, empty)}
+									>
+										<!-- item -->
+										{#each stackSection?.items as item (item.id)}
+											<div
+												id={item?.id}
+												class="item"
+												animate:flip={{ duration: $motion }}
+												tabindex="-1"
+												style={itemStyles(item?.type)}
+											>
+												<Content {item} />
+											</div>
+										{/each}
+									</div>
+								</section>
+							{/each}
+						</div>
+
+						<!-- normal -->
+					{:else}
+						{@const empty = $editMode && !section?.items?.length}
+						<SectionHeader {view} {section} />
+						<div
+							class="items"
+							style={sectionStyles($itemHeight, $editMode, $motion, empty)}
+						>
+							{#each section?.items as item (item.id)}
+								<div
+									id={item?.id}
+									class="item"
+									animate:flip={{ duration: $motion }}
+									tabindex="-1"
+									style={itemStyles(item?.type)}
+								>
+									<Content {item} />
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</section>
+			{/each}
+		</main>
+
+		<ConfigButtons />
+	</Modal>
+{/if}
+
+<style>
+	main {
+		grid-area: main;
+		padding: 0 2rem 2rem;
+		display: grid;
+		gap: 1.5rem;
+		outline: transparent;
+		align-content: start;
+	}
+
+	section {
+		display: grid;
+		align-content: start;
+	}
+
+	.horizontal-stack {
+		display: grid;
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
+		gap: 0.4rem;
+		border-radius: 0.65rem;
+		outline-offset: 3px;
+	}
+
+	.items {
+		border-radius: 0.6rem;
+		outline-offset: -2px;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, 14.5rem);
+		grid-auto-rows: min-content;
+		gap: 0.4rem;
+		border-radius: 0.6rem;
+		height: 100%;
+	}
+
+	.item {
+		position: relative;
+		border-radius: 0.65rem;
+	}
+
+	/* Phone and Tablet (portrait) */
+	@media all and (max-width: 768px) {
+		main {
+			padding: 0 1.25rem 1.25rem 1.25rem;
+		}
+
+		.horizontal-stack {
+			grid-auto-flow: row;
+			gap: 1.5rem;
+		}
+
+		.items {
+			display: flex;
+			flex-wrap: wrap;
+		}
+	}
+</style>

--- a/src/lib/Sidebar/Index.svelte
+++ b/src/lib/Sidebar/Index.svelte
@@ -328,6 +328,7 @@
 								extra_sensor={item?.extra_sensor}
 								icon_pack={item?.icon_pack}
 								show_apparent={item?.show_apparent}
+								popup={item?.popup}
 							/>
 						</button>
 					{/if}

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -20,6 +20,7 @@ export interface Addons {
 export interface Dashboard {
 	views: Views[];
 	sidebar: SidebarItem[];
+	popups: Popups[]
 	theme?: string;
 	hide_views?: boolean;
 	hide_sidebar?: boolean;
@@ -32,6 +33,12 @@ export interface Views {
 	icon?: string;
 	sections?: Section[];
 	isDndShadowItem?: boolean;
+}
+
+export interface Popups {
+	id?: number;
+	name?: string;
+	sections?: Section[];
 }
 
 export interface Section {
@@ -54,6 +61,12 @@ export interface ViewItem {
 	id?: number;
 	name?: string;
 	icon?: string;
+	sections?: any[];
+}
+
+export interface PopupItem {
+	id?: number;
+	name?: string;
 	sections?: any[];
 }
 
@@ -163,6 +176,7 @@ export interface TemplateItem {
 	type?: string;
 	id?: number;
 	template?: string;
+	popup?: string;
 }
 
 export interface TimeItem {
@@ -188,4 +202,5 @@ export interface WeatherItem {
 	extra_sensor?: string;
 	extra_sensor_icon?: string;
 	show_apparent?: boolean;
+	popup?: string;
 }


### PR DESCRIPTION
Hello. This is my attempt at implementing https://github.com/matt8707/ha-fusion/issues/25. Or at the very least to demonstrate the idea.

Here it is in action:

https://github.com/matt8707/ha-fusion/assets/2185791/bc395121-9b16-445f-a4f0-189d7395cc93

It works by adding a `popup` property to content items (only Template and Weather so far) and a new section `popups` to `dashboard.yaml` where popups are defined using exactly the same structure and content items as views currently:
```yaml
views:
sidebar:
  - type: weather
      entity_id: weather.openweathermap
      weather_sensor: sensor.openweathermap_weather
      extra_sensor: sensor.openweathermap_forecast_precipitation_probability
      extra_sensor_icon: mdi:drop
      icon_pack: meteocons
      id: 2790676343766
      show_apparent: true
      popup: Pogoda
  - type: template
    template: '{{ states[''sensor.template_sidebar''].attributes.open }}'
    id: 2790676343775
    popup: Kontaktrony
popups:
  - name: Pogoda
    id: 6467602449611
    sections:
      - type: horizontal-stack
        id: 5078078976670
        sections:
          - name: Pogoda
            id: 2171067078835
            items:
              - type: button
                entity_id: sensor.openweathermap_forecast_pressure
                id: 5008685947164
              - type: button
                entity_id: sensor.openweathermap_forecast_wind_bearing
                marquee: true
                id: 4795962599238
              - type: button
                entity_id: sensor.openweathermap_forecast_wind_speed
                id: 7351468287678
              - type: button
                id: 2038492812514
                entity_id: sensor.openweathermap_temperature
            sections: []
  - name: Kontaktrony
    id: 217080290836
    sections:
      - type: horizontal-stack
        sections:
          - name: Piwnica
            items:
              - type: button
                id: 9786682200580
                entity_id: binary_sensor.okno_wodomierz_prawe_contact
                icon: fluent-emoji-flat:window
              - type: button
                id: 7680866993651
                entity_id: binary_sensor.okno_wodomierz_lewe_contact
                icon: fluent-emoji-flat:window
            id: 9934789372920
            sections: []
          - name: Parter
            items:
              - type: button
                id: 5591283887827
                entity_id: binary_sensor.drzwi_wejsciowe_contact
                icon: fluent-emoji-flat:door
              - type: button
                id: 4385497833543
                entity_id: binary_sensor.drzwi_do_ogrodu_contact
                icon: fluent-emoji-flat:door
            id: 4639158644077
            sections: []
        id: 924870224236
        items: []
```

### Limitations:
* I'm not an expert on CSS, so displaying the views in the modal is not correct
* This is advanced feature (meaning no configuring popups from UI)
* In the current design, `popup` property and associated handling needs to be added to all modals. In the end this property should be generalized and be inheritable, as it could be applicable to any content item really.

I'm leaving this here for review mostly and in the hopes someone else contributes or for the future.

