### PR TITLE
Weather Forecast Icons On Safari

### DIFF
--- a/src/lib/Sidebar/WeatherForecast.svelte
+++ b/src/lib/Sidebar/WeatherForecast.svelte
@@ -78,19 +78,20 @@
 					{/if}
 				</div>
 
-				{#if forecast.icon.local}
-					<icon class="icon">
-						<img
-							src={`${forecast.icon.icon_variant_day}.svg`}
-							alt={entity_state}
-							width="100%"
-							height="100%"
-						/>
-					</icon>
-				{:else}
-					<Icon class="icon" icon={forecast.icon.icon_variant_day} width="100%" height="100%"
-					></Icon>
-				{/if}
+				<div class="icon">
+					{#if forecast.icon.local}
+						<icon class="ff-fill">
+							<img
+								src={`${forecast.icon.icon_variant_day}.svg`}
+								alt={entity_state}
+								width="100%"
+								height="100%"
+							/>
+						</icon>
+					{:else}
+						<Icon icon={forecast.icon.icon_variant_day} width="100%" height="100%"></Icon>
+					{/if}
+				</div>
 
 				<div class="temp">
 					{Math.round(forecast.temperature)}{attributes?.temperature_unit || '°'}
@@ -110,9 +111,9 @@
 		grid-column-gap: 0px;
 		grid-row-gap: 0px;
 		grid-template-areas:
-			'day day'
+			'day'
 			'icon'
-			'temp temp';
+			'temp';
 		text-shadow: 0px 0px 5px rgba(0, 0, 0, 0.1);
 		text-overflow: ellipsis;
 		overflow: hidden;
@@ -129,14 +130,14 @@
 	}
 
 	.day {
-		grid-area: 'day';
+		grid-area: day;
 		justify-content: center;
 		display: flex;
 		width: 3.6rem;
 	}
 
 	.icon {
-		grid-area: 'icon';
+		grid-area: icon;
 		width: 3.6rem;
 		height: 3.6rem;
 		display: flex;
@@ -146,12 +147,17 @@
 	}
 
 	.temp {
-		grid-area: 'temp';
+		grid-area: temp;
 		justify-content: center;
 		display: flex;
 		white-space: nowrap;
 		width: 3.6rem;
 		overflow: hidden;
 		text-shadow: 0px 0px 5px rgba(0, 0, 0, 0.1);
+	}
+
+	.ff-fill {
+		width: 3.6rem;
+		height: 3.6rem;
 	}
 </style>


### PR DESCRIPTION
### Weather Forecast Icons On Safari

Managed to replicate the bug reported in https://github.com/matt8707/ha-fusion/issues/259. I've fixed the icons not displaying properly in safari now.

I've attached screenshots of the three browsers I've tested on.All tested on Mac is:
- **Left**: Firefox 122.0
- **Middle**: Chrome 120.0.6099.216
- **Right**: Safari 16.6 (18615.3.12.11.2)

![Screenshot 2024-01-24 at 18 42 09](https://github.com/matt8707/ha-fusion/assets/7600557/b6169651-22c7-4fd5-9897-9c7bbb8defef)
![Screenshot 2024-01-24 at 18 43 28](https://github.com/matt8707/ha-fusion/assets/7600557/c9d74b54-90e3-40ac-89cc-c9aa45ca9467)
