### PR TITLE
Fix for ON states for climate entities #278

### DIFF
--- a/src/lib/Components/StateLogic.svelte
+++ b/src/lib/Components/StateLogic.svelte
@@ -49,6 +49,10 @@
 		{@html title}
 	{/if}
 
+	<!--  Climate -->
+{:else if getDomain(entity_id) === 'climate' && attributes?.hvac_action}
+	{$lang(attributes?.hvac_action)}
+
 	<!--  Humidifier -->
 {:else if getDomain(entity_id) === 'humidifier' && entity?.state === 'on' && attributes?.action}
 	{$lang('humidifier_' + attributes?.action)}

--- a/src/lib/Main/Button.svelte
+++ b/src/lib/Main/Button.svelte
@@ -8,7 +8,7 @@
 		lang,
 		motion,
 		onStates,
-		climateOnStates,
+		climateHvacActionToMode,
 		ripple,
 		states
 	} from '$lib/Stores';
@@ -36,8 +36,6 @@
 
 	/** display loader if no state change has occurred within `$motion`ms */
 	let delayLoading: ReturnType<typeof setTimeout> | null;
-
-	let stateOn: boolean;
 
 	/**
 	 * Observes changes in the `last_updated` property of an entity.
@@ -74,11 +72,9 @@
 	// icon is image if extension, e.g. test.png
 	$: image = icon?.includes('.');
 
-	$: if (getDomain(entity_id) === 'climate') {
-		stateOn = $climateOnStates?.includes(entity?.attributes.hvac_action);
-	} else {
-		stateOn = $onStates?.includes(entity?.state);
-	}
+	$: stateOn = $onStates?.includes(
+        attributes?.hvac_action ? $climateHvacActionToMode?.[attributes?.hvac_action] : entity?.state
+    );
 
 	/**
 	 * Toggles the state of the specified entity

--- a/src/lib/Main/Button.svelte
+++ b/src/lib/Main/Button.svelte
@@ -8,6 +8,7 @@
 		lang,
 		motion,
 		onStates,
+		climateOnStates,
 		ripple,
 		states
 	} from '$lib/Stores';
@@ -35,6 +36,8 @@
 
 	/** display loader if no state change has occurred within `$motion`ms */
 	let delayLoading: ReturnType<typeof setTimeout> | null;
+
+	let stateOn: boolean;
 
 	/**
 	 * Observes changes in the `last_updated` property of an entity.
@@ -71,7 +74,11 @@
 	// icon is image if extension, e.g. test.png
 	$: image = icon?.includes('.');
 
-	$: stateOn = $onStates?.includes(entity?.state);
+	$: if (getDomain(entity_id) === 'climate') {
+		stateOn = $climateOnStates?.includes(entity?.attributes.hvac_action);
+	} else {
+		stateOn = $onStates?.includes(entity?.state);
+	}
 
 	/**
 	 * Toggles the state of the specified entity

--- a/src/lib/Stores.ts
+++ b/src/lib/Stores.ts
@@ -46,13 +46,15 @@ export const onStates = readable([
 ]);
 
 // climate states
-export const climateOnStates = readable([
-	'cooling',
-	'drying',
-	'fan',
-	'heating',
-	'preheating'
-]);
+export const climateHvacActionToMode = readable<Record<string, string>>({
+	cooling: 'cool',
+	drying: 'dry',
+	fan: 'fan_only',
+	preheating: 'heat',
+	heating: 'heat',
+	idle: 'off',
+	off: 'off'
+});
 
 // drawer
 export const drawerSearch = writable<string | undefined>();

--- a/src/lib/Stores.ts
+++ b/src/lib/Stores.ts
@@ -45,6 +45,15 @@ export const onStates = readable([
 	'gas'
 ]);
 
+// climate states
+export const climateOnStates = readable([
+	'cooling',
+	'drying',
+	'fan',
+	'heating',
+	'preheating'
+]);
+
 // drawer
 export const drawerSearch = writable<string | undefined>();
 export const focusSearch = writable<boolean>(false);


### PR DESCRIPTION
Fixes #278

I left all the `heat`, `dry`, `cool` in onStates for now as I'm not sure if they are not used for something else to determine state.

Now only `hvac_action` is taken for climate state and then it shows as I would expect it to:
![obraz](https://github.com/anarion80/ha-fusion/assets/2185791/ca21286a-ea36-43d6-b048-32234e3545a1)