### PR TITLE
Feature: Auto Dismiss Modals

### DIFF
--- a/src/lib/Components/Toggle.svelte
+++ b/src/lib/Components/Toggle.svelte
@@ -1,10 +1,11 @@
 <script>
 	// https://svelte.dev/repl/35d77f2ab11e4197a19ffd8e7c4ac74e
 	export let checked = false;
+	export let name = 'toggle';
 </script>
 
 <label class="switch">
-	<input name="toggle" type="checkbox" bind:checked on:change />
+	<input {name} type="checkbox" bind:checked on:change />
 	<span class="slider" data-exclude-drag-modal />
 </label>
 

--- a/src/lib/Modal/CodeConfig.svelte
+++ b/src/lib/Modal/CodeConfig.svelte
@@ -172,7 +172,7 @@
 <svelte:window on:keydown={handleKeyDown} />
 
 {#if isOpen}
-	<Modal size="large" on:transitionend={() => (transitionend = true)}>
+	<Modal size="large" on:transitionend={() => (transitionend = true)} bypass_auto_dismiss={true}>
 		<h1 slot="title">{$lang('raw')}</h1>
 
 		<br />

--- a/src/lib/Modal/Index.svelte
+++ b/src/lib/Modal/Index.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {
 		configuration,
+		editMode,
 		motion,
 		autocompleteOpen,
 		ripple,
@@ -121,7 +122,11 @@
 	});
 
 	function addAutoDismissIfNeeded() {
-		if ($configuration?.addons?.['auto_dismiss_modal']?.enabled === 'on' && !bypass_auto_dismiss) {
+		if (
+			$configuration?.addons?.['auto_dismiss_modal']?.enabled === 'on' &&
+			!bypass_auto_dismiss &&
+			$editMode === false
+		) {
 			modalTimeout = setTimeout(
 				() => {
 					closeModal();

--- a/src/lib/Settings/Addons.svelte
+++ b/src/lib/Settings/Addons.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { lang } from '$lib/Stores';
+	import { configuration, lang } from '$lib/Stores';
+	import InputClear from '$lib/Components/InputClear.svelte';
+	import Toggle from '$lib/Components/Toggle.svelte';
 
 	export let data: any;
 
@@ -12,7 +14,6 @@
 </script>
 
 <h2>{$lang('addons')}</h2>
-
 <p class="overflow">
 	{$lang('docs')} -
 	<a {href} target="blank">{href}</a>
@@ -32,6 +33,29 @@
 			on:focus={handleFocus}
 			on:blur={handleFocus}
 		/>
+	</div>
+
+	<div class="item">
+		<h3>{$lang('auto')} {$lang('closed')} {$lang('overview')}</h3>
+		<div class="container">
+			<div>
+				<input
+					name="dismiss_timeout"
+					class="input"
+					type="number"
+					placeholder="60"
+					autocomplete="off"
+					spellcheck="false"
+					value={data?.configuration?.addons?.['auto_dismiss_modal']?.timeout || ''}
+				/>
+			</div>
+			<div style:margin-left="1.3rem">
+				<Toggle
+					name="auto_dismiss_modal"
+					checked={data?.configuration?.addons?.['auto_dismiss_modal']?.enabled === 'on' || false}
+				/>
+			</div>
+		</div>
 	</div>
 
 	<!-- <div class="item">
@@ -67,6 +91,12 @@
 		display: grid;
 		grid-template-columns: repeat(1, 1fr);
 		gap: 0.5rem;
+	}
+
+	.container {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
 	}
 
 	h3 {

--- a/src/lib/Settings/Index.svelte
+++ b/src/lib/Settings/Index.svelte
@@ -44,7 +44,13 @@
 
 			const addons = {
 				...(form.youtube_watching && { youtube_watching: { entity_id: form.youtube_watching } }),
-				...(form.maptiler && { maptiler: { apikey: form.maptiler } })
+				...(form.maptiler && { maptiler: { apikey: form.maptiler } }),
+				...((form.auto_dismiss_modal || form.dismiss_timeout) && {
+					auto_dismiss_modal: {
+						timeout: form.dismiss_timeout || 60,
+						enabled: form.auto_dismiss_modal || 'off'
+					}
+				})
 			};
 
 			const custom_js = form.custom_js ? Boolean(form.custom_js === 'true') : undefined;
@@ -102,7 +108,7 @@
 <svelte:window on:keydown={handleKeydown} />
 
 {#if isOpen}
-	<Modal>
+	<Modal bypass_auto_dismiss={true}>
 		<h1 slot="title">{$lang('settings')}</h1>
 
 		<form id="settings" name="settings" bind:this={formElement}>

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -15,6 +15,10 @@ export interface Addons {
 	maptiler?: {
 		apikey: string;
 	};
+	auto_dismiss_modal?: {
+		enabled: string;
+		timeout: string;
+	};
 }
 
 export interface Dashboard {


### PR DESCRIPTION
This feature add the capability to set a timeout for the modal pop ups.
I did this based off the assumption for the #308 I did see you closed that out but looks like your change was for toast and closing them based on an event for HA.

The main driver is wall mounted tables, that I wanted the screen to go back to the main screen after a certain period of time. 
IE. I tap a light to control the color, I can walk away and when I return later it will be back on my main screen.

The one caveat that I have noticed, any settings changes do not take effect until you refresh the page. Something to take a look at.

<img width="515" alt="image" src="https://github.com/matt8707/ha-fusion/assets/1327947/d962682a-9017-4021-8747-e759f5b4b500">


https://github.com/matt8707/ha-fusion/assets/1327947/891fc176-373e-4331-a9cd-e94d48fa7828

