### PR TITLE
Add custom state template and custom service call to button

### DIFF
--- a/data/dashboard.yaml
+++ b/data/dashboard.yaml
@@ -13,6 +13,42 @@ views:
             id: 2171067078835
             items:
               - type: button
+                id: 1063494948270
+                entity_id: switch.switch_buero_pc_sonos_strip
+                name: O's PC, Sonos, Strip
+                extras:
+                  state_template: >
+                    {% if(is_state('switch.switch_buero_pc_sonos_strip', 'on'))
+                    %}
+                      {{ "An • " + states('sensor.switch_buero_pc_sonos_strip_power', with_unit=True) }}
+                    {% elif(is_state('switch.switch_buero_pc_sonos_strip',
+                    'off')) %}
+                      Aus
+                    {% else %}
+                      {{ states('switch.switch_buero_pc_sonos_strip') }}
+                    {% endif %}
+                icon: mdi:power-socket-de
+              - type: button
+                id: 1113219359563
+                entity_id: switch.switch_buero_monitore_co
+                name: J's PC, Monitore
+                more_info: false
+                icon: mdi:power-socket-de
+                extras:
+                  state_template: >
+                    {% if(is_state('switch.switch_buero_monitore_co', 'on')) %}
+                      {{ "An • " + states('sensor.switch_buero_monitore_co_power', with_unit=True) }}
+                    {% elif(is_state('switch.switch_buero_monitore_co', 'off'))
+                    %}
+                      Aus
+                    {% else %}
+                      {{ states('switch.switch_buero_monitore_co') }}
+                    {% endif %}
+                  service_domain: light
+                  service_service: turn_on
+                  service_data:
+                    entity_id: light.hue_buero
+              - type: button
                 entity_id: light.studio_dator
                 id: 5008685947164
               - type: button

--- a/src/lib/Stores.ts
+++ b/src/lib/Stores.ts
@@ -83,7 +83,7 @@ export const highlightView = writable<boolean>(false);
 // sidebar
 export const timers = writable<{ [key: string]: { pausedState: string } }>({});
 export const barErrors = writable<{ [key: string]: string }>({});
-export const templates = writable<{ [key: number]: string }>({});
+export const templates = writable<{ [key: string]: string }>({});
 export const demo = writable<{ [key: string]: string | undefined }>({
 	graph: undefined,
 	sensor: undefined,

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -72,6 +72,12 @@ export interface ButtonItem {
 	precision: number;
 	more_info?: boolean;
 	attribute?: string;
+	extras?: {
+		state_template?: string;
+		service_domain?: string;
+		service_service?: string;
+		service_data?: object;
+	};
 }
 
 export type SidebarItem = BarItem &


### PR DESCRIPTION
Adds the option to define a few extras for advanced user via an extra key `extras` in the YAML configuration.

1. It's possible to define a template for the displayed button state:
  ```yaml
- type: button
  id: 1063494948270
  entity_id: switch.switch_buero_pc_sonos_strip
  name: O's PC, Sonos, Strip
  extras:
    state_template: >
      {% if(is_state('switch.switch_buero_pc_sonos_strip', 'on'))
      %}
      {{ "An • " + states('sensor.switch_buero_pc_sonos_strip_power', with_unit=True) }}
    {% elif(is_state('switch.switch_buero_pc_sonos_strip',
    'off')) %}
      Aus
    {% else %}
      {{ states('switch.switch_buero_pc_sonos_strip') }}
    {% endif %}
```

2. It's possible to define a custom service call. If a entity_id exists in service_data it is used for the "waiting animation" of the button icon:
  ```yaml
- type: button
  id: 1113219359563
  entity_id: switch.switch_buero_monitore_co
  name: J's PC, Monitore
  more_info: false
  icon: mdi:power-socket-de
  extras:
    service_domain: light
    service_service: turn_on
    service_data:
      entity_id: light.hue_buero
  ```

Fixes #209 