### PR TITLE
Use start and pause instead of toggle as service commands for vacuum

### DIFF
--- a/src/lib/Main/Button.svelte
+++ b/src/lib/Main/Button.svelte
@@ -109,7 +109,7 @@
 			siren: 'toggle',
 			switch: 'toggle',
 			timer: state === 'active' ? 'pause' : 'start',
-			vacuum: 'toggle'
+			vacuum: state === 'cleaning' ? 'pause' : 'start'
 		};
 
 		switch (domain) {


### PR DESCRIPTION
The vacuum service does not support the `toggle` command so the Vacuum button click does not do anything. 
This error is recorded in the console log:
`2.QL3D25OP.js:1 Uncaught (in promise) {code: 'not_found', message: 'Service vacuum.toggle not found.', translation_key: 'service_not_found', translation_placeholders: {…}, translation_domain: 'homeassistant'}`

Instead of toggle, this PR proposes to use the `start` and `pause` commands, which are supported for vacuums:
https://www.home-assistant.io/integrations/vacuum/