### PR TITLE
LightModal bug if light doesn't support color don't show color

### DIFF
--- a/src/lib/Modal/LightModal.svelte
+++ b/src/lib/Modal/LightModal.svelte
@@ -238,7 +238,7 @@
 			</div>
 		{/if}
 
-		{#if supports?.BRIGHTNESS && selTab !== 'white'}
+		{#if supports?.COLOR && selTab !== 'white'}
 			<ColorPicker
 				{entity}
 				{colorMode}


### PR DESCRIPTION
Issue where if a device doesn't support color we are still displaying the colorpicker