### PR TITLE
add group support to getTogglableService

### DIFF
--- a/src/lib/Utils.ts
+++ b/src/lib/Utils.ts
@@ -115,6 +115,10 @@ export function getTogglableService(entity: HassEntity) {
 		case 'remote':
 			return 'homeassistant.toggle';
 
+		case 'group':
+			service = state === 'off' ? 'turn_on' : 'turn_off';
+			return `homeassistant.${service}`;
+
 		case 'scene':
 			service = 'turn_on';
 			break;


### PR DESCRIPTION
At this moment adding a group of lights/switches (entities like group.xxx) to a button would trigger a 'maximum call stack exceeded' error, because the handler for group in `getTogglableService` is not implemented.