### PR TITLE
Adding time period option in sidebar graph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-# This file is only for development, environment should be
-# set in docker, and when using addon `hassUrl` is irrelevant.
-
-HASS_URL=http://192.168.1.241:8123

--- a/src/lib/Modal/GraphConfig.svelte
+++ b/src/lib/Modal/GraphConfig.svelte
@@ -54,11 +54,11 @@
 		{ id: '6hours', label: `6 ${$lang('hours')}` },
 		{ id: '12hours', label: `12 ${$lang('hours')}` },
 		{ id: '24hours', label: `24 ${$lang('hours')}` },
-		{ id: '2days',  label: `2 ${$lang('day')}` },
+		{ id: '2days', label: `2 ${$lang('day')}` },
 		{ id: '4days', label: `4 ${$lang('day')}` },
 		{ id: '1week', label: `1 ${$lang('week')}` },
 		{ id: '2weeks', label: `2 ${$lang('week')}` },
-		{ id: '1month',  label: `1 ${$lang('month')}` }
+		{ id: '1month', label: `1 ${$lang('month')}` }
 	];
 
 	function minMax(key: string | number | undefined) {

--- a/src/lib/Modal/GraphConfig.svelte
+++ b/src/lib/Modal/GraphConfig.svelte
@@ -50,6 +50,17 @@
 		{ id: 'month', label: $lang('period_month') }
 	];
 
+	const timePeriodOptions = [
+		{ id: '6hours', label: `6 ${$lang('hours')}` },
+		{ id: '12hours', label: `12 ${$lang('hours')}` },
+		{ id: '24hours', label: `24 ${$lang('hours')}` },
+		{ id: '2days',  label: `2 ${$lang('day')}` },
+		{ id: '4days', label: `4 ${$lang('day')}` },
+		{ id: '1week', label: `1 ${$lang('week')}` },
+		{ id: '2weeks', label: `2 ${$lang('week')}` },
+		{ id: '1month',  label: `1 ${$lang('month')}` }
+	];
+
 	function minMax(key: string | number | undefined) {
 		return Math.min(Math.max(parseInt(key as string), range.min), range.max);
 	}
@@ -108,6 +119,7 @@
 				entity_id={sel?.entity_id}
 				name={sel?.name}
 				period={sel?.period}
+				time_period={sel?.time_period}
 				stroke={minMax(stroke)}
 			/>
 		</div>
@@ -159,25 +171,16 @@
 			/>
 		{/if}
 
-		<h2>start_time</h2>
+		<h2>{`${$lang('time')} ${$lang('period')}`}</h2>
 
-		<input
-			class="input"
-			type="text"
-			placeholder={new Date(Date.now() - 2629800 * 1000).toISOString()}
-			autocomplete="off"
-			spellcheck="false"
-		/>
-
-		<h2>end_time</h2>
-
-		<input
-			class="input"
-			type="text"
-			placeholder={new Date().toISOString()}
-			autocomplete="off"
-			spellcheck="false"
-		/>
+		{#if timePeriodOptions}
+			<Select
+				options={timePeriodOptions}
+				placeholder={`${$lang('time')} ${$lang('period')}`}
+				value={sel?.time_period}
+				on:change={(event) => set('time_period', event)}
+			/>
+		{/if}
 
 		<h2>{$lang('size')}</h2>
 

--- a/src/lib/Sidebar/Graph.svelte
+++ b/src/lib/Sidebar/Graph.svelte
@@ -8,6 +8,8 @@
 	export let entity_id: string | undefined;
 	export let name: string | undefined = undefined;
 	export let period = 'day';
+	// default to 24 hours
+	export let time_period = '24hours';
 	export let stroke = 2;
 
 	let width: number;
@@ -15,7 +17,6 @@
 	let chartData: any[] = [];
 	let resizeTimeout: ReturnType<typeof setTimeout>;
 	let isResizing: boolean;
-	let start_time = new Date(Date.now() - 2629800 * 1000).toISOString();
 	let end_time = new Date().toISOString();
 	let m = { x: 0, y: 0 };
 	let point: { [x: string]: any };
@@ -60,7 +61,7 @@
 		}, 200);
 	}
 
-	$: if (entity_id || period) {
+	$: if (entity_id || period || time_period) {
 		fetchData();
 	}
 
@@ -98,6 +99,21 @@
 		}).format(Number(entity?.state));
 	}
 
+	function calculateStartTime(tr: string): string {
+		const trMap: { [key: string]: number } = {
+			'6hours': 6 * 60 * 60,
+			'12hours': 12 * 60 * 60,
+			'24hours': 24 * 60 * 60,
+			'2days': 2 * 24 * 60 * 60,
+			'4days': 4 * 24 * 60 * 60,
+			'1week': 1 * 7 * 24 * 60 * 60,
+			'2weeks': 2 * 7 * 24 * 60 * 60,
+			'1month': 30 * 24 * 60 * 60
+		};
+
+		return new Date(Date.now() - trMap[tr || '24hours'] * 1000).toISOString();
+	}
+
 	function fetchData() {
 		if (!entity_id) return;
 
@@ -105,7 +121,7 @@
 			conn
 				?.sendMessagePromise({
 					type: 'recorder/statistics_during_period',
-					start_time: start_time,
+					start_time: calculateStartTime(time_period),
 					end_time: end_time,
 					statistic_ids: [entity_id],
 					period: period || 'day'

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -170,6 +170,7 @@ export interface GraphItem {
 	type?: string;
 	id?: number;
 	entity_id?: string;
+	time_period?: string;
 	period?: string;
 	stroke?: number;
 	hide_mobile?: boolean;


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
The sidebar graph card start time is hardcoded which makes the graph data less relevant

**Describe the solution you'd like**
It should be able to dynamically show me a last 7 days or so option that is configurable

**What changes were made?**
replacing start time and end time with dynamic period for sidebar graph card