### PR TITLE
fix(weather): apply `icon_pack` to the current-conditions widget

### DIFF
--- a/src/lib/Sidebar/Weather.svelte
+++ b/src/lib/Sidebar/Weather.svelte
@@ -2,6 +2,8 @@
 	import { states, lang } from '$lib/Stores';
 	import type { HassEntity } from 'home-assistant-js-websocket';
 	import Icon from '@iconify/svelte';
+	import { iconMapMaterialSymbolsLight, iconMapMeteocons, iconMapWeatherIcons } from '$lib/Weather';
+	import type { WeatherIconSet, WeatherIconConditions, WeatherIconMapping } from '$lib/Weather';
 
 	export let sel: any;
 
@@ -14,7 +16,25 @@
 
 	// icon pack
 	$: below_horizon = $states?.['sun.sun']?.state === 'below_horizon';
-	$: src = `weather/meteocons/${entity?.state}-${below_horizon ? 'night' : 'day'}.svg`;
+
+	let iconSet: WeatherIconSet;
+	$: {
+		if (sel?.icon_pack === 'materialsymbolslight') {
+			iconSet = iconMapMaterialSymbolsLight;
+		} else if (sel?.icon_pack === 'meteocons') {
+			iconSet = iconMapMeteocons;
+		} else if (sel?.icon_pack === 'weathericons') {
+			iconSet = iconMapWeatherIcons;
+		} else {
+			iconSet = iconMapMeteocons;
+		}
+	}
+
+	$: icon = iconSet?.conditions?.[
+		entity?.state as keyof WeatherIconConditions
+	] as WeatherIconMapping;
+
+	$: iconName = icon && (below_horizon ? icon.icon_variant_night : icon.icon_variant_day);
 
 	// sensor
 	$: sensor = sel?.sensor && $states?.[sel?.sensor];
@@ -23,7 +43,11 @@
 {#if entity && entity?.state !== 'unavailable'}
 	<div class="container">
 		<div class="icon">
-			<img {src} width="100%" height="100%" alt="" />
+			{#if icon?.local}
+				<img src="{iconName}.svg" width="100%" height="100%" alt="" />
+			{:else if iconName}
+				<Icon icon={iconName} width="100%" height="100%"></Icon>
+			{/if}
 		</div>
 
 		{#if attributes?.temperature}


### PR DESCRIPTION
## Problem

The `weather` sidebar widget ignores its own `icon_pack` setting.

`src/lib/Sidebar/Weather.svelte` hardcodes the meteocons path:

```js
// icon pack
$: below_horizon = $states?.['sun.sun']?.state === 'below_horizon';
$: src = `weather/meteocons/${entity?.state}-${below_horizon ? 'night' : 'day'}.svg`;
```

This is inconsistent with the rest of the codebase:

- `src/lib/Modal/WeatherConfig.svelte` renders an icon pack `<Select>` for this widget and writes `icon_pack` to the dashboard config.
- `WeatherItem.icon_pack?: string` is declared in `src/lib/Types.ts`.
- `src/lib/Sidebar/WeatherForecast.svelte` already resolves `icon_pack` correctly.

So a user can pick "Material Symbols Light" or "Weather Icons" for the weather widget, the value is persisted, and nothing changes — while the forecast row directly beneath it *does* change. The result is a dashboard showing two different icon styles side by side with no way to reconcile them.

## Fix

Resolve the icon set using the same branch `WeatherForecast.svelte` uses, then pick the day/night variant and render according to the mapping's `local` flag (`<img>` for bundled sets like meteocons, `<Icon>` for iconify-based sets).

Defaults are unchanged: with no `icon_pack` set, `iconMapMeteocons` is selected, and every meteocons condition is `local: true`, so existing dashboards render exactly as before.

## Notes

- The day/night variant now comes from the icon mapping (`icon_variant_night` / `icon_variant_day`) rather than being string-built, so sets whose day and night icons share a name work correctly.
- Previously an unrecognised entity state produced a broken `<img>` pointing at a nonexistent file. Now nothing renders if the condition isn't in the map.
- Markup for the default (meteocons) path is structurally unchanged — the `<img>` remains a direct child of `div.icon`, so no CSS changes are needed. I deliberately did not copy the `<icon class="ff-fill">` wrapper from `WeatherForecast.svelte`, since that class is scoped to that component.

## Testing

Against `main` (7bb033b):

- `pnpm run check` → 0 errors, 0 warnings
- `pnpm run lint` → passes (prettier + eslint), exit 0
- `pnpm run build` → succeeds, exit 0

Also verified on a live dashboard that the current-conditions icon follows `icon_pack`, and that omitting the setting keeps the existing meteocons rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
